### PR TITLE
fix(skills): clarify-spec Trigger-Schwelle hoch, prompt-architect Auto-Kette raus

### DIFF
--- a/clarify-spec/README.md
+++ b/clarify-spec/README.md
@@ -1,35 +1,32 @@
 # clarify-spec
 
-**Automatische Auftragsklärung für Claude Code**
+**Auftragsklärung mit hoher Schwelle für Claude Code**
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blue)](https://github.com/anthropics/skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Problem
 
-Du gibst Claude einen vagen Auftrag → Claude rät was gemeint ist → Ergebnis passt nicht → Nacharbeit und Frustration.
+Du gibst Claude einen Auftrag, der wirklich mehrere Ziele bedeuten kann. Ohne kurze Klärung würde Claude eine Richtung wählen, die vielleicht nicht gemeint war.
 
 ```
-User: "Mach den Export besser"
-Claude: *implementiert irgendwas*
+User: "Räum die Auth auf"
+Claude: *ändert Token-Handling, obwohl eigentlich Tests gemeint waren*
 User: "Das meinte ich nicht..."
 ```
 
 ## Lösung
 
-Dieser Skill **aktiviert sich automatisch** bei vagen Aufträgen und stellt gezielte Rückfragen BEVOR Code geschrieben wird.
+Dieser Skill klärt nur dann, wenn nach eigener Recherche eine echte Ziel-Mehrdeutigkeit bleibt. Kurze Aufträge, vage Verben und fehlende Dateinamen sind kein Grund für Rückfragen: Claude sucht zuerst selbst im Projekt und trifft dann eine Senior-Entscheidung.
 
 ```
-User: "Mach den Export besser"
-Claude: "Kurze Rückfrage:
-         1. Welchen Export? (PPTX / Markdown / beide)
-         2. Was genau stört dich am aktuellen Export?
-         (Oder sag 'mach einfach')"
-User: "PPTX, das Logo fehlt"
-Claude: "Präzisierter Auftrag:
-         Ziel: Logo zum PPTX-Export hinzufügen
-         Datei: presentationBuilder.ts
-         Soll ich loslegen?"
+User: "Räum die Auth auf"
+Claude: *prüft Repo, Issues und bestehende Auth-Dateien*
+Claude: "Kurze Klärung:
+         1. Meinst du Refactor, Tests oder Token-Rotation?
+         2. Soll produktives Login-Verhalten unverändert bleiben?"
+User: "Tests, Verhalten unverändert"
+Claude: *arbeitet danach autonom bis fertig*
 ```
 
 ## Installation
@@ -48,16 +45,18 @@ git clone https://github.com/YOUR_USERNAME/clarify-spec.git
 
 ## Aktivierung
 
-### Automatisch (empfohlen)
+### Automatisch mit hoher Schwelle
 
-Der Skill aktiviert sich **automatisch** bei:
+Der Skill aktiviert sich nur, wenn nach eigener Recherche mindestens eines davon bleibt:
 
 | Signal | Beispiel |
 |--------|----------|
-| Kurzer Auftrag (<20 Wörter) | "Mach den Export besser" |
-| Keine Dateinamen | "Optimiere die Performance" |
-| Vage Verben | besser, optimieren, fixen, machen |
-| Unsichere Sprache | irgendwie, vielleicht, mal eben |
+| Ziel ist widersprüchlich | "mach es wie besprochen", aber es gibt keine Notiz |
+| Mehrere grundverschiedene Ziele sind plausibel | "räum die Auth auf" kann Refactor, Tests oder Token-Rotation heißen |
+| Information fehlt im Repo | "nutz die neue API", aber es gibt keine API-Doku |
+| Irreversible Aktion mit unklarem Scope | "lösch die alten Branches" |
+
+Nicht auslösen bei kurzen Aufträgen, fehlenden Dateinamen oder vagen Verben allein. Das sind normale Alltagsaufträge.
 
 ### Manuell
 
@@ -71,23 +70,17 @@ Der Skill aktiviert sich **automatisch** bei:
 
 ```
 ┌─────────────────────────────────────────────────┐
-│ 1. VAGHEITS-CHECK                               │
-│    Auftrag < 20 Wörter? Keine Dateinamen?       │
-│    Vage Verben?                                 │
+│ 1. EIGENRECHERCHE                              │
+│    Grep/Glob/Read, CLAUDE.md/AGENTS.md, History │
 │              ↓                                  │
-│ 2. KONTEXT SAMMELN (still)                      │
-│    Relevante Dateien, CLAUDE.md prüfen          │
+│ 2. ECHTE MEHRDEUTIGKEIT?                       │
+│    Ziel offen, Info fehlt, irreversibler Scope  │
 │              ↓                                  │
-│ 3. RÜCKFRAGEN (2-4)                             │
-│    Was genau? Wo? Erfolgskriterium?             │
+│ 3. FRAGEN EINMAL BÜNDELN                       │
+│    Max. 4 Fragen in einem AskUserQuestion-Aufruf│
 │              ↓                                  │
-│ 4. STRUKTURIERTER AUFTRAG                       │
-│    Ziel, Scope, Erfolgskriterien                │
-│              ↓                                  │
-│ 5. BESTÄTIGUNG                                  │
-│    ja → Ausführen                               │
-│    nein → Abbrechen                             │
-│    anpassen → Modifizieren                      │
+│ 4. AUTONOM DURCHARBEITEN                       │
+│    Keine Frage-Schleife, kein Stopp pro Schritt │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -101,16 +94,16 @@ Du kannst die Klärung überspringen:
 
 ## Beispiele
 
-### Vager Auftrag
+### Mehrdeutiger Auftrag
 
 ```
-User: "Optimiere die Performance"
+User: "Räum die Auth auf"
 
-Claude: "Welche Performance meinst du?
-1. Ladezeit der Seite?
-2. API Response Time?
-3. Build-Zeit?
-4. Bundle Size?"
+Claude: *prüft Auth-Dateien und Projektkontext*
+Claude: "Welche Richtung meinst du?
+1. Refactor ohne Verhaltensänderung
+2. Mehr Tests für bestehendes Verhalten
+3. Token-/Session-Logik ändern"
 ```
 
 ### Klarer Auftrag (keine Nachfrage)
@@ -124,11 +117,11 @@ Claude: *führt direkt aus*
 
 ## Konfiguration
 
-Der Skill ist absichtlich **aggressiv** konfiguriert:
+Der Skill ist absichtlich zurückhaltend konfiguriert:
 
-> **LIEBER EINMAL ZU OFT NACHFRAGEN als falsch implementieren.**
+> **Erst selbst recherchieren. Nur echte Ziel-Mehrdeutigkeit einmal klären. Danach autonom arbeiten.**
 
-Wenn dir das zu viel ist, nutze "mach einfach" zum Überspringen.
+Wenn du gar keine Klärung möchtest, nutze "mach einfach" zum Überspringen.
 
 ## Kompatibilität
 

--- a/clarify-spec/SKILL.md
+++ b/clarify-spec/SKILL.md
@@ -27,9 +27,9 @@ triggers:
 
 ## Grundhaltung
 
-Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 "aggressiv, lieber einmal
-zu oft") hat eine Frage-Schleife erzeugt, in der Lara nur noch getippt hat statt
-Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
+Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 mit aggressiver
+Rueckfrage-Schwelle) hat eine Frage-Schleife erzeugt, in der Lara nur noch
+getippt hat statt Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
 
 Die Regel ist: **Erst selbst nachsehen. Dann eine Senior-Entscheidung treffen.
 Nur wenn eine echte Ziel-Mehrdeutigkeit bleibt — einmal gebuendelt fragen.**

--- a/clarify-spec/SKILL.md
+++ b/clarify-spec/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: clarify-spec
 description: |
-  AKTIVIERT SICH AUTOMATISCH bei vagen Auftraegen. LIEBER EINMAL ZU OFT NACHFRAGEN als falsch implementieren.
+  Klaert einen Auftrag NUR wenn er echt mehrdeutig ist und eigenes Recherchieren
+  (Grep/Glob/Read der Projektdateien) die Unklarheit nicht aufloest.
 
-  Erkennungsmerkmale (EINES genuegt!):
-  - Auftrag <25 Woerter
-  - Keine konkreten Dateinamen/Pfade
-  - Vage Verben: besser, optimieren, fixen, machen, aendern, verbessern, anpassen, erweitern, refactoren, aufraumen, ueberarbeiten
-  - Unsichere Sprache: irgendwie, vielleicht, mal eben, schnell, einfach, bisschen, koennte, sollte
-  - Fehlende Erfolgskriterien: Kein damit, sodass, weil, um zu
-  - Relative Begriffe ohne Kontext: schneller, besser, schoener, einfacher
+  NICHT triggern bei: kurzen Auftraegen, vagen Verben allein ("fix X", "mach Y besser"),
+  fehlenden Dateinamen. Das sind normale Alltagsauftraege — die werden durch
+  Eigenrecherche + Senior-Entscheidung erledigt, nicht durch Rueckfragen.
 
-  Output ist STRUKTURIERTES JSON fuer prompt-architect Skill.
-  Escape: mach einfach, keine Rueckfragen, entscheide selbst ueberspringt Klaerung.
+  Triggern NUR bei echter Mehrdeutigkeit: das Ziel selbst ist unklar oder
+  widerspruechlich, mehrere grundlegend verschiedene Interpretationen sind moeglich,
+  oder es fehlt Information die nirgends im Repo steht.
+
+  Wenn er triggert: ALLE Fragen EINMAL gebuendelt (ein AskUserQuestion-Aufruf,
+  bis 4 Fragen) — danach autonom durcharbeiten, kein Stopp pro Schritt.
+  Escape: "mach einfach" / "keine Rueckfragen" / "entscheide selbst" ueberspringt komplett.
 triggers:
   - /clarify
   - /spec
@@ -21,125 +23,107 @@ triggers:
   - /klaeren
 ---
 
-# Clarify-Spec v2.0: Automatische Auftragsklarung
+# Clarify-Spec v3.0: Auftragsklaerung mit hoher Schwelle
 
-## AKTIVIERUNG: Aggressiv - Lieber einmal zu oft!
+## Grundhaltung
 
-### AUTOMATISCH bei diesen Signalen (EINES genuegt!)
+Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 "aggressiv, lieber einmal
+zu oft") hat eine Frage-Schleife erzeugt, in der Lara nur noch getippt hat statt
+Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
 
-| Signal | Beispiele | Warum problematisch |
-|--------|-----------|---------------------|
-| Kurzer Auftrag (<25 Woerter) | Mach den Export besser | Zu wenig Kontext |
-| Keine Dateinamen/Pfade | Optimiere die Performance | Scope unklar |
-| Vage Verben | besser, optimieren, fixen, machen, aendern, verbessern | Nicht operationalisierbar |
-| Unsichere Sprache | irgendwie, vielleicht, mal eben, schnell | Signalisiert Unklarheit |
-| Fehlende Erfolgskriterien | Kein damit, sodass, weil | Kein Ziel definiert |
-| Relative Begriffe | schneller, besser, schoener, einfacher | Ohne Baseline bedeutungslos |
-| Implizite Annahmen | Das uebliche, wie immer, standard | Kontext fehlt |
+Die Regel ist: **Erst selbst nachsehen. Dann eine Senior-Entscheidung treffen.
+Nur wenn eine echte Ziel-Mehrdeutigkeit bleibt — einmal gebuendelt fragen.**
 
-### NICHT aktivieren NUR wenn ALLE erfuellt:
-- Konkreter Dateiname/Pfad genannt UND
-- Klares, messbares Ziel definiert UND
-- Erfolgskriterium erkennbar UND
-- Expliziter Skip-Befehl (mach einfach, keine Rueckfragen)
+Ein kurzer Auftrag ist kein Problem. Ein vages Verb ist kein Problem. Ein fehlender
+Dateiname ist kein Problem — den findet man mit Grep. Ein *echt mehrdeutiges Ziel*
+ist ein Problem.
+
+## Wann dieser Skill triggert (hohe Schwelle)
+
+NUR wenn nach eigener Recherche mindestens eines davon zutrifft:
+
+| Echte Mehrdeutigkeit | Beispiel |
+|---|---|
+| Das Ziel selbst ist unklar/widerspruechlich | "mach es wie besprochen" — es gibt keine Notiz, was besprochen wurde |
+| Mehrere grundlegend verschiedene Interpretationen | "raeum die Auth auf" — koennte Refactor, Logging, Token-Rotation oder Tests heissen, alle plausibel |
+| Information fehlt, die NIRGENDS im Repo steht | "nutz die neue API" — keine API im Code, kein Doc, kein Issue |
+| Irreversible Aktion mit unklarem Scope | "loesch die alten Branches" — welche genau? unwiederbringlich |
+
+## Wann dieser Skill NICHT triggert
+
+Bei all dem: NICHT fragen — recherchieren und arbeiten.
+
+- Kurzer Auftrag ("fix den Export-Bug") → Bug suchen, fixen.
+- Vages Verb ("mach die Seite besser") → wenn der Kontext den Mangel klarmacht
+  (offensichtlicher Bug, kaputtes Layout): beheben. Wenn wirklich offen: EINE
+  gebuendelte Frage, was "besser" konkret heisst — aber erst nach Ansehen der Seite.
+- Kein Dateiname genannt → Glob/Grep findet die Datei.
+- "wie immer" / "das uebliche" → Git-History und bestehende Patterns zeigen das Uebliche.
 
 ## Workflow
 
-### Phase 1: Vagheits-Check (STRENG)
+### Phase 1: Eigenrecherche zuerst (immer, still, ohne User)
 
-Pruefe jeden Auftrag gegen diese Checkliste:
+Bevor irgendeine Frage gestellt wird:
 
-[ ] Konkrete Datei/Komponente genannt?
-[ ] Klares, messbares Ziel definiert?
-[ ] Erfolgskriterium erkennbar?
-[ ] Scope abgegrenzt?
-[ ] Keine vagen Verben verwendet?
+1. Relevante Dateien suchen (Glob/Grep) und lesen.
+2. CLAUDE.md / AGENTS.md / Memory pruefen.
+3. Git-History und aehnliche bestehende Implementierungen ansehen.
+4. No-Touch-Zones identifizieren.
 
-Weniger als 4 Haken = RUECKFRAGEN STELLEN!
+Nach Phase 1 ist die Frage in den allermeisten Faellen beantwortet. Dann: **direkt
+arbeiten, Phase 2-4 ueberspringen.**
 
-### Phase 2: Kontext sammeln (still, ohne User-Interaktion)
+### Phase 2: Echtheits-Pruefung der Unklarheit
 
-1. Relevante Dateien im Projekt suchen (Glob)
-2. CLAUDE.md / AGENTS.md pruefen
-3. No-Touch Zones identifizieren
-4. Aehnliche bestehende Implementierungen finden
+Bleibt nach Phase 1 etwas offen — pruefen: Ist das eine **echte
+Ziel-Mehrdeutigkeit** (Tabelle oben) oder nur ein Detail, das eine
+Senior-Entscheidung verträgt?
 
-### Phase 3: Gezielte Rueckfragen (2-4, priorisiert)
+- Detail, das man vernuenftig selbst entscheiden kann → entscheiden, Annahme im
+  Ergebnis dokumentieren, weiterarbeiten.
+- Echte Ziel-Mehrdeutigkeit → Phase 3.
 
-Format - kurz und praezise:
+### Phase 3: EIN gebuendelter Fragen-Block
 
-Bevor ich loslege - kurze Klaerung:
+Wenn gefragt werden muss: **alle offenen Punkte auf einmal** ueber das
+`AskUserQuestion`-Tool (bis zu 4 Fragen gleichzeitig). Nicht nacheinander, nicht
+ueber mehrere Nachrichten verteilt.
 
-1. [KONKRETSTE FRAGE - WAS genau?]
-2. [ZWEITWICHTIGSTE FRAGE - WO/Welche Datei?]
-3. [Optional: Erfolgskriterium?]
-4. [Optional: Gibt es ein Beispiel/Referenz?]
+Fragen-Prioritaet — nur was wirklich offen ist:
 
-(Oder sag mach einfach - dann entscheide ich nach bestem Wissen.)
+| Prio | Typ | Wann fragen |
+|------|-----|-------------|
+| 1 | ZIEL | Das Ziel selbst ist mehrdeutig — welche Interpretation? |
+| 2 | SCOPE | Bei irreversiblen Aktionen: was genau ist betroffen? |
+| 3 | INFO | Information fehlt, die nirgends im Repo steht |
 
-Fragen-Prioritaet:
+WAS/WO-Fragen ("welche Datei?", "Frontend oder Backend?") gehoeren NICHT hierher —
+die beantwortet Phase 1.
 
-| Prio | Typ | Beispiel-Fragen |
-|------|-----|-----------------|
-| 1 | WAS | Was genau meinst du mit besser? Welches Problem soll geloest werden? |
-| 2 | WO | Welche Datei/Komponente ist betroffen? Frontend oder Backend? |
-| 3 | ERFOLG | Woran erkenne ich, dass es fertig ist? Was ist das erwartete Ergebnis? |
-| 4 | BEISPIEL | Gibt es eine Referenz/Screenshot? Wie sieht der gewuenschte Output aus? |
-| 5 | KONTEXT | Fuer welchen Use Case? Wer ist der Nutzer dieser Funktion? |
+### Phase 4: Nach den Antworten — autonom
 
-### Phase 4: Strukturierter Output (JSON fuer prompt-architect)
-
-Nach Antwort des Users, generiere strukturiertes JSON mit:
-- clarified_task.goal: Praezises Ziel in 1-2 Saetzen
-- clarified_task.problem_statement: Was ist das Problem
-- clarified_task.scope.files: Betroffene Dateien
-- clarified_task.scope.no_touch: Nicht anfassen
-- clarified_task.success_criteria: Messbare Kriterien
-- clarified_task.constraints: Einschraenkungen
-- metadata.original_request: Urspruenglicher Auftrag
-- metadata.confidence: high/medium/low
-
-### Phase 5: Bestaetigung mit Prompt-Vorschau
-
-Zeige dem User eine lesbare Zusammenfassung mit Ziel, Problem, Scope, Erfolgskriterien, Constraints.
-
-Frage: Soll ich loslegen? (ja / nein / anpassen: ...)
-Oder: /prompt-architect fuer einen strukturierten Best-Practice Prompt
-
-### Phase 6: Reaktion auf Bestaetigung
-
-| Antwort | Aktion |
-|---------|--------|
-| ja / ok / los / mach | Ausfuehren mit internem JSON-Kontext |
-| nein / stop / abbrechen | Abbrechen, nachfragen was stattdessen |
-| anpassen: ... | JSON modifizieren, erneut zeigen |
-| /prompt-architect | An prompt-architect Skill uebergeben |
-| mach einfach | Mit eigenem Ermessen ausfuehren |
+Sobald die Antworten da sind: **durcharbeiten bis fertig.** Keine weitere
+Rueckfrage, kein Approval-Checkpoint pro Schritt, kein erneutes Klaeren. Nur ein
+echter, vorher unsichtbarer Blocker rechtfertigt eine weitere Frage.
 
 ## Escape Hatches
 
-User kann Klaerung jederzeit ueberspringen mit:
-- Mach einfach
-- Entscheide selbst
-- Keine Rueckfragen
-- Egal, hauptsache X funktioniert
-- Just do it
+Klaerung wird komplett uebersprungen bei:
+- "Mach einfach" / "Entscheide selbst" / "Keine Rueckfragen"
+- "Egal, hauptsache X funktioniert" / "Just do it"
 
-Bei Escape: Mit bestem Wissen ausfuehren, aber Annahmen dokumentieren.
+Bei Escape: mit bestem Wissen ausfuehren, getroffene Annahmen am Ende kurz nennen.
 
-## Integration mit prompt-architect
+## Verhaeltnis zu prompt-architect
 
-Nach erfolgreicher Klaerung kann der User /prompt-architect aufrufen.
-Der prompt-architect Skill nutzt das JSON aus Phase 4, um einen vollstaendigen
-Best-Practice Prompt nach Claude 4.x Standards zu generieren.
+`prompt-architect` triggert NICHT mehr automatisch nach diesem Skill. Wenn ein
+strukturierter Prompt gebraucht wird, ruft der User `/prompt-architect` explizit auf.
 
-Workflow:
-clarify-spec -> JSON Output -> prompt-architect -> Ausfuehrung
-
-## Metrik: Erfolg
+## Erfolgs-Metrik
 
 Der Skill ist erfolgreich wenn:
-- Weniger Nacharbeit nach Implementierung
-- User sagt Ja, genau das meinte ich
-- Erste Implementierung erfuellt alle Kriterien
-- Keine Das meinte ich nicht Situationen
+- Lara NICHT in einer Frage-Schleife sitzt.
+- Normale Alltagsauftraege ohne Rueckfrage erledigt werden.
+- Gefragt wird nur bei echter Mehrdeutigkeit — und dann genau einmal.
+- Keine "das meinte ich nicht"-Situationen, weil Phase 1 den Kontext liefert.

--- a/commands/clarify-spec.md
+++ b/commands/clarify-spec.md
@@ -1,141 +1,123 @@
-# /clarify-spec - Spezifikations-Klaerung
+# /clarify-spec - Spezifikations-Klaerung mit hoher Schwelle
 
-Du bist ein Spezifikations-Assistent, der unklare Anfragen praezisiert, BEVOR Aktionen ausgefuehrt werden.
+Du bist ein Spezifikations-Assistent, der nur dann klaert, wenn nach eigener
+Recherche eine echte Ziel-Mehrdeutigkeit bleibt.
+
+Dieser Command darf keine Frage-Schleife erzeugen. Kurze Auftraege, vage Verben
+oder fehlende Dateinamen sind kein Grund zum Stoppen. Suche zuerst selbst im
+Projekt und arbeite danach autonom weiter.
 
 ## Trigger
 
-Dieser Skill wird aktiviert, wenn der User eine Aktion anfordert, aber **konkrete Werte fehlen**:
+Aktiviere diese Klaerung nur, wenn nach Repo-Recherche mindestens eines davon
+zutrifft:
 
-| Aktions-Verb | Fehlende Information | Beispiel |
-|--------------|---------------------|----------|
-| teste | URL, Endpoint, Datei | "Teste das Preview" |
-| pruefe | Was genau, Kriterien | "Pruef die API" |
-| deploye | Umgebung, Branch | "Deploy das" |
-| oeffne | URL, Pfad, Datei | "Oeffne die Seite" |
-| navigiere | Ziel-URL | "Navigiere zur App" |
-| lade | Datei, Quelle | "Lade die Daten" |
-| starte | Server, Service | "Starte den Dev-Server" |
-| verbinde | Ziel, Credentials | "Verbinde zur DB" |
+| Echte Mehrdeutigkeit | Beispiel |
+| --- | --- |
+| Ziel ist widerspruechlich | "mach es wie besprochen", aber es gibt keine Notiz |
+| Mehrere grundverschiedene Ziele sind plausibel | "raeum die Auth auf" kann Refactor, Tests oder Token-Rotation heissen |
+| Information fehlt nirgends auffindbar | "nutz die neue API", aber es gibt keine API-Doku im Repo |
+| Irreversible Aktion mit unklarem Scope | "loesch die alten Branches" |
+
+Nicht triggern bei:
+
+- Kurzen Auftraegen.
+- Vagen Verben allein.
+- Fehlenden Dateinamen oder Pfaden.
+- Fragen, die per Grep/Glob/Read, Git-History, PR-Text oder Projekt-Doku
+  beantwortbar sind.
 
 ## Workflow
 
-### 1. Erkennung (automatisch)
+### 1. Eigenrecherche zuerst
 
-Wenn ein Aktions-Verb ohne konkreten Wert erkannt wird:
+Bevor du fragst:
 
-```
-User: "Teste das Preview-Deployment"
-Problem: Welche URL? Es gibt mehrere Preview-Deployments.
-```
+1. Relevante Dateien per Glob/Grep suchen und lesen.
+2. CLAUDE.md, AGENTS.md, README und Projekt-Doku pruefen.
+3. Git-History, offene PR-Beschreibung oder vorhandene Patterns anschauen.
+4. No-Touch-Zonen und irreversible Aktionen erkennen.
 
-### 2. Strukturierte Rueckfrage
+Wenn die Recherche eine plausible Senior-Entscheidung erlaubt: direkt arbeiten.
 
-Stelle gezielte Fragen mit konkreten Optionen:
+### 2. Echtheits-Pruefung
+
+Bleibt etwas offen, trenne:
+
+- Technisches Detail mit vernuenftiger Default-Entscheidung -> selbst entscheiden,
+  am Ende kurz dokumentieren.
+- Echte Ziel-Mehrdeutigkeit oder irreversible Aktion -> einmal fragen.
+
+### 3. Ein gebuendelter Fragenblock
+
+Stelle alle offenen Punkte in einem einzigen Aufruf des verfuegbaren Frage-Tools
+(bis zu 4 Fragen). Keine Rueckfragen nacheinander, kein separater
+Approval-Stopp pro Datei.
+
+Beispiel:
 
 ```markdown
 ## Klarstellung benoetigt
 
-**Aktion:** Teste Preview-Deployment
-**Fehlt:** Konkrete URL
+Ich habe Repo-Kontext, Doku und History geprueft. Offen bleibt nur die
+Zielrichtung:
 
-### Optionen:
+1. Soll "Auth aufraeumen" Refactor ohne Verhaltensaenderung, mehr Tests oder
+   Token-/Session-Logik bedeuten?
+2. Darf produktives Login-Verhalten geaendert werden?
 
-1. **Letztes Vercel Preview** (empfohlen)
-   `https://fabrikiq-xxx.vercel.app`
-
-2. **Production**
-   `https://app.fabrikiq.com`
-
-3. **Lokaler Dev-Server**
-   `http://localhost:5173`
-
-4. **Andere URL angeben**
-
-Welche Option soll ich verwenden?
+Nach deiner Antwort arbeite ich autonom bis fertig.
 ```
 
-### 3. Bestaetigung
+### 4. Danach autonom durcharbeiten
 
-Nach Auswahl:
-- Wiederhole die vollstaendige Aktion mit konkreten Werten
-- Fuehre erst nach Bestaetigung aus
+Nach der Antwort:
+
+- Vollstaendige Aufgabe ausfuehren.
+- Keine weitere Klaerung, ausser ein echter, vorher unsichtbarer Blocker taucht
+  auf.
+- Annahmen und verifizierte Checks am Ende dokumentieren.
 
 ## Regeln
 
-1. **NIEMALS raten** - Immer nachfragen wenn unklar
-2. **NIEMALS AskUserQuestion** - Nutze diesen strukturierten Dialog
-3. **NIEMALS suchen und dann fragen** - Erst fragen, dann handeln
-4. **IMMER Optionen anbieten** - Keine offenen Fragen
-5. **IMMER projektspezifisch** - Nutze bekannte URLs/Pfade aus CLAUDE.md
+1. Erst suchen, dann nur bei echter Ziel-Mehrdeutigkeit fragen.
+2. Alle Fragen einmal buendeln.
+3. Keine offenen WAS/WO-Fragen, wenn Projekt-Recherche sie beantworten kann.
+4. Keine obsolete Projektpfade oder Provider erfinden.
+5. Irreversible Aktionen, Production-Deploys und externe Send-Aktionen nur mit
+   klarer Bestaetigung.
 
-## Kontext-Nutzung
+## Beispiele
 
-Nutze Projektkontext aus CLAUDE.md fuer relevante Optionen:
+### Kein Trigger
 
-```yaml
-fabrikIQ:
-  production: https://app.fabrikiq.com
-  preview_pattern: https://fabrikiq-*.vercel.app
-  local: http://localhost:5173
-  api_base: /api/
+```text
+User: "Teste das Preview"
 
-Endpoints:
-  - /api/analyze
-  - /api/auth
-  - /api/chat
-  - /api/admin
+Vorgehen:
+1. PR-Checks/Kommentare nach Preview-URL durchsuchen.
+2. Wenn genau eine aktuelle Preview existiert: testen.
+3. Wenn mehrere gleich aktuelle Previews existieren: einmal gebuendelt fragen.
 ```
 
-## Beispiel-Dialog
+### Trigger
 
-```
-User: "Teste die API"
+```text
+User: "Loesch die alten Branches"
 
-Claude:
-## Klarstellung benoetigt
-
-**Aktion:** API testen
-**Fehlt:** Welcher Endpoint, welche Umgebung
-
-### Endpoint:
-1. `/api/analyze` - Hauptanalyse
-2. `/api/auth` - Authentifizierung
-3. `/api/chat` - Chat-Assistent
-4. `/api/admin` - Admin-Panel
-5. Alle Endpoints
-
-### Umgebung:
-A. Production (app.fabrikiq.com)
-B. Preview (letztes Deployment)
-C. Lokal (localhost:5173)
-
-Bitte waehle Endpoint (1-5) und Umgebung (A-C).
-
-User: "2B"
-
-Claude: Verstanden. Teste /api/auth auf dem letzten Preview-Deployment.
-[Fuehrt Aktion aus]
-```
-
-## Anti-Patterns (NICHT machen)
-
-```
-# FALSCH: Selbst suchen
-"Lass mich nach Preview-Deployments suchen..."
-
-# FALSCH: Offene Frage
-"Welche URL moechtest du testen?"
-
-# FALSCH: Annahme treffen
-"Ich nehme an, du meinst Production..."
-
-# RICHTIG: Strukturierte Optionen
-"Welche der folgenden URLs: 1) ... 2) ... 3) ..."
+Vorgehen:
+1. Branches und Merge-Status pruefen.
+2. Falls Scope unklar bleibt: konkrete Kandidatenliste in einer Frage bestaetigen
+   lassen.
+3. Danach nur die bestaetigten Branches loeschen.
 ```
 
 ## Integration
 
-Dieser Skill wird automatisch getriggert durch:
-- Hook-System mit Keyword-Matching
-- CLAUDE.md Instruktion "Clarify-Spec Automatik"
-- skill-rules.json mit `enforcement: "suggest"`
+Dieser Command spiegelt `clarify-spec` v3.0:
+
+- Hohe Trigger-Schwelle.
+- Eigenrecherche vor Rueckfrage.
+- Ein Fragenblock, danach autonom.
+- Keine automatische Weiterleitung zu `prompt-architect`; dieser Skill laeuft nur
+  bei explizitem `/prompt-architect`.

--- a/prompt-architect/README.md
+++ b/prompt-architect/README.md
@@ -26,12 +26,13 @@ cp SKILL.md README.md ~/.claude/skills/prompt-architect/
 
 ## Verwendung
 
-### Nach clarify-spec (empfohlen)
+### Mit vorheriger Klärung
 
 1. User gibt vagen Auftrag
-2. clarify-spec stellt Rueckfragen, generiert JSON
-3. /prompt-architect transformiert JSON in Best-Practice Prompt
-4. Ausfuehrung mit Quality Gates
+2. clarify-spec klaert nur bei echter Ziel-Mehrdeutigkeit und nur einmal gebuendelt
+3. User ruft /prompt-architect explizit auf
+4. prompt-architect transformiert den geklaerten Kontext in einen Best-Practice Prompt
+5. Ausfuehrung mit Quality Gates
 
 ### Standalone
 
@@ -56,10 +57,10 @@ cp SKILL.md README.md ~/.claude/skills/prompt-architect/
 
 ## Workflow
 
-clarify-spec (Anforderungen sammeln)
+clarify-spec (optional, nur bei echter Mehrdeutigkeit)
        |
        v
-  JSON Output
+expliziter /prompt-architect Aufruf
        |
        v
 prompt-architect (Best-Practice Prompt)

--- a/prompt-architect/SKILL.md
+++ b/prompt-architect/SKILL.md
@@ -8,8 +8,8 @@ description: |
   - Anthropic Claude 4.x Best Practices: Explizitheit, Contract-Style, Examples beat Adjectives
   - Pipelines over Prompts Philosophie
   
-  AKTIVIERT SICH AUTOMATISCH nach clarify-spec oder bei /prompt-architect.
-  Produziert strukturierten, ausfuehrbaren Prompt mit allen Best Practices.
+  Wird AUSSCHLIESSLICH per /prompt-architect aufgerufen — KEINE automatische
+  Aktivierung. Produziert strukturierten, ausfuehrbaren Prompt mit allen Best Practices.
 triggers:
   - /prompt-architect
   - /prompt
@@ -28,12 +28,16 @@ triggers:
 
 ## AKTIVIERUNG
 
-### Automatisch nach clarify-spec
-Wenn clarify-spec ein JSON Output generiert hat, kann prompt-architect
-dieses JSON in einen strukturierten Prompt transformieren.
+**Nur manuell.** Dieser Skill aktiviert sich NICHT automatisch — auch nicht nach
+clarify-spec. Die fruehere Auto-Kette (clarify-spec -> prompt-architect) wurde
+entfernt, weil sie eine Klaerungs-Schleife verstaerkt hat.
 
 ### Manuell mit Trigger
 /prompt-architect [Aufgabenbeschreibung]
+
+Falls ein clarify-spec-Lauf vorausging und ein JSON-Ergebnis vorliegt, kann
+prompt-architect dieses JSON nutzen — aber nur, wenn der User /prompt-architect
+explizit aufruft.
 
 ## Die 4 Beginner Moves (Nate B. Jones)
 

--- a/prompt-architect/SKILL.md
+++ b/prompt-architect/SKILL.md
@@ -145,7 +145,8 @@ Before responding, verify:
 ### Schritt 1: Input analysieren
 
 Akzeptiert:
-1. JSON von clarify-spec (bevorzugt)
+1. JSON oder Kontext aus einem vorherigen clarify-spec-Lauf, wenn der User danach
+   explizit /prompt-architect aufruft
 2. Freie Textbeschreibung
 3. Kombiniert mit aktuellem Projekt-Kontext
 
@@ -259,8 +260,8 @@ Der generierte Prompt ist optimiert fuer:
 
 ## Integration
 
-### Mit clarify-spec
-clarify-spec -> JSON -> prompt-architect -> Ausfuehrung
+### Nach clarify-spec
+clarify-spec -> User ruft /prompt-architect explizit auf -> Prompt -> Ausfuehrung
 
 ### Mit /supervisor
 prompt-architect -> Prompt -> /supervisor -> Quality Gates -> Ergebnis

--- a/skills/clarify-spec/README.md
+++ b/skills/clarify-spec/README.md
@@ -1,35 +1,32 @@
 # clarify-spec
 
-**Automatische Auftragsklärung für Claude Code**
+**Auftragsklärung mit hoher Schwelle für Claude Code**
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blue)](https://github.com/anthropics/skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Problem
 
-Du gibst Claude einen vagen Auftrag → Claude rät was gemeint ist → Ergebnis passt nicht → Nacharbeit und Frustration.
+Du gibst Claude einen Auftrag, der wirklich mehrere Ziele bedeuten kann. Ohne kurze Klärung würde Claude eine Richtung wählen, die vielleicht nicht gemeint war.
 
 ```
-User: "Mach den Export besser"
-Claude: *implementiert irgendwas*
+User: "Räum die Auth auf"
+Claude: *ändert Token-Handling, obwohl eigentlich Tests gemeint waren*
 User: "Das meinte ich nicht..."
 ```
 
 ## Lösung
 
-Dieser Skill **aktiviert sich automatisch** bei vagen Aufträgen und stellt gezielte Rückfragen BEVOR Code geschrieben wird.
+Dieser Skill klärt nur dann, wenn nach eigener Recherche eine echte Ziel-Mehrdeutigkeit bleibt. Kurze Aufträge, vage Verben und fehlende Dateinamen sind kein Grund für Rückfragen: Claude sucht zuerst selbst im Projekt und trifft dann eine Senior-Entscheidung.
 
 ```
-User: "Mach den Export besser"
-Claude: "Kurze Rückfrage:
-         1. Welchen Export? (PPTX / Markdown / beide)
-         2. Was genau stört dich am aktuellen Export?
-         (Oder sag 'mach einfach')"
-User: "PPTX, das Logo fehlt"
-Claude: "Präzisierter Auftrag:
-         Ziel: Logo zum PPTX-Export hinzufügen
-         Datei: presentationBuilder.ts
-         Soll ich loslegen?"
+User: "Räum die Auth auf"
+Claude: *prüft Repo, Issues und bestehende Auth-Dateien*
+Claude: "Kurze Klärung:
+         1. Meinst du Refactor, Tests oder Token-Rotation?
+         2. Soll produktives Login-Verhalten unverändert bleiben?"
+User: "Tests, Verhalten unverändert"
+Claude: *arbeitet danach autonom bis fertig*
 ```
 
 ## Installation
@@ -48,16 +45,18 @@ git clone https://github.com/YOUR_USERNAME/clarify-spec.git
 
 ## Aktivierung
 
-### Automatisch (empfohlen)
+### Automatisch mit hoher Schwelle
 
-Der Skill aktiviert sich **automatisch** bei:
+Der Skill aktiviert sich nur, wenn nach eigener Recherche mindestens eines davon bleibt:
 
 | Signal | Beispiel |
 |--------|----------|
-| Kurzer Auftrag (<20 Wörter) | "Mach den Export besser" |
-| Keine Dateinamen | "Optimiere die Performance" |
-| Vage Verben | besser, optimieren, fixen, machen |
-| Unsichere Sprache | irgendwie, vielleicht, mal eben |
+| Ziel ist widersprüchlich | "mach es wie besprochen", aber es gibt keine Notiz |
+| Mehrere grundverschiedene Ziele sind plausibel | "räum die Auth auf" kann Refactor, Tests oder Token-Rotation heißen |
+| Information fehlt im Repo | "nutz die neue API", aber es gibt keine API-Doku |
+| Irreversible Aktion mit unklarem Scope | "lösch die alten Branches" |
+
+Nicht auslösen bei kurzen Aufträgen, fehlenden Dateinamen oder vagen Verben allein. Das sind normale Alltagsaufträge.
 
 ### Manuell
 
@@ -71,23 +70,17 @@ Der Skill aktiviert sich **automatisch** bei:
 
 ```
 ┌─────────────────────────────────────────────────┐
-│ 1. VAGHEITS-CHECK                               │
-│    Auftrag < 20 Wörter? Keine Dateinamen?       │
-│    Vage Verben?                                 │
+│ 1. EIGENRECHERCHE                              │
+│    Grep/Glob/Read, CLAUDE.md/AGENTS.md, History │
 │              ↓                                  │
-│ 2. KONTEXT SAMMELN (still)                      │
-│    Relevante Dateien, CLAUDE.md prüfen          │
+│ 2. ECHTE MEHRDEUTIGKEIT?                       │
+│    Ziel offen, Info fehlt, irreversibler Scope  │
 │              ↓                                  │
-│ 3. RÜCKFRAGEN (2-4)                             │
-│    Was genau? Wo? Erfolgskriterium?             │
+│ 3. FRAGEN EINMAL BÜNDELN                       │
+│    Max. 4 Fragen in einem AskUserQuestion-Aufruf│
 │              ↓                                  │
-│ 4. STRUKTURIERTER AUFTRAG                       │
-│    Ziel, Scope, Erfolgskriterien                │
-│              ↓                                  │
-│ 5. BESTÄTIGUNG                                  │
-│    ja → Ausführen                               │
-│    nein → Abbrechen                             │
-│    anpassen → Modifizieren                      │
+│ 4. AUTONOM DURCHARBEITEN                       │
+│    Keine Frage-Schleife, kein Stopp pro Schritt │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -101,16 +94,16 @@ Du kannst die Klärung überspringen:
 
 ## Beispiele
 
-### Vager Auftrag
+### Mehrdeutiger Auftrag
 
 ```
-User: "Optimiere die Performance"
+User: "Räum die Auth auf"
 
-Claude: "Welche Performance meinst du?
-1. Ladezeit der Seite?
-2. API Response Time?
-3. Build-Zeit?
-4. Bundle Size?"
+Claude: *prüft Auth-Dateien und Projektkontext*
+Claude: "Welche Richtung meinst du?
+1. Refactor ohne Verhaltensänderung
+2. Mehr Tests für bestehendes Verhalten
+3. Token-/Session-Logik ändern"
 ```
 
 ### Klarer Auftrag (keine Nachfrage)
@@ -124,11 +117,11 @@ Claude: *führt direkt aus*
 
 ## Konfiguration
 
-Der Skill ist absichtlich **aggressiv** konfiguriert:
+Der Skill ist absichtlich zurückhaltend konfiguriert:
 
-> **LIEBER EINMAL ZU OFT NACHFRAGEN als falsch implementieren.**
+> **Erst selbst recherchieren. Nur echte Ziel-Mehrdeutigkeit einmal klären. Danach autonom arbeiten.**
 
-Wenn dir das zu viel ist, nutze "mach einfach" zum Überspringen.
+Wenn du gar keine Klärung möchtest, nutze "mach einfach" zum Überspringen.
 
 ## Kompatibilität
 

--- a/skills/clarify-spec/SKILL.md
+++ b/skills/clarify-spec/SKILL.md
@@ -27,9 +27,9 @@ triggers:
 
 ## Grundhaltung
 
-Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 "aggressiv, lieber einmal
-zu oft") hat eine Frage-Schleife erzeugt, in der Lara nur noch getippt hat statt
-Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
+Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 mit aggressiver
+Rueckfrage-Schwelle) hat eine Frage-Schleife erzeugt, in der Lara nur noch
+getippt hat statt Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
 
 Die Regel ist: **Erst selbst nachsehen. Dann eine Senior-Entscheidung treffen.
 Nur wenn eine echte Ziel-Mehrdeutigkeit bleibt — einmal gebuendelt fragen.**

--- a/skills/clarify-spec/SKILL.md
+++ b/skills/clarify-spec/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: clarify-spec
 description: |
-  AKTIVIERT SICH AUTOMATISCH bei vagen Auftraegen. LIEBER EINMAL ZU OFT NACHFRAGEN als falsch implementieren.
+  Klaert einen Auftrag NUR wenn er echt mehrdeutig ist und eigenes Recherchieren
+  (Grep/Glob/Read der Projektdateien) die Unklarheit nicht aufloest.
 
-  Erkennungsmerkmale (EINES genuegt!):
-  - Auftrag <25 Woerter
-  - Keine konkreten Dateinamen/Pfade
-  - Vage Verben: besser, optimieren, fixen, machen, aendern, verbessern, anpassen, erweitern, refactoren, aufraumen, ueberarbeiten
-  - Unsichere Sprache: irgendwie, vielleicht, mal eben, schnell, einfach, bisschen, koennte, sollte
-  - Fehlende Erfolgskriterien: Kein damit, sodass, weil, um zu
-  - Relative Begriffe ohne Kontext: schneller, besser, schoener, einfacher
+  NICHT triggern bei: kurzen Auftraegen, vagen Verben allein ("fix X", "mach Y besser"),
+  fehlenden Dateinamen. Das sind normale Alltagsauftraege — die werden durch
+  Eigenrecherche + Senior-Entscheidung erledigt, nicht durch Rueckfragen.
 
-  Output ist STRUKTURIERTES JSON fuer prompt-architect Skill.
-  Escape: mach einfach, keine Rueckfragen, entscheide selbst ueberspringt Klaerung.
+  Triggern NUR bei echter Mehrdeutigkeit: das Ziel selbst ist unklar oder
+  widerspruechlich, mehrere grundlegend verschiedene Interpretationen sind moeglich,
+  oder es fehlt Information die nirgends im Repo steht.
+
+  Wenn er triggert: ALLE Fragen EINMAL gebuendelt (ein AskUserQuestion-Aufruf,
+  bis 4 Fragen) — danach autonom durcharbeiten, kein Stopp pro Schritt.
+  Escape: "mach einfach" / "keine Rueckfragen" / "entscheide selbst" ueberspringt komplett.
 triggers:
   - /clarify
   - /spec
@@ -21,125 +23,107 @@ triggers:
   - /klaeren
 ---
 
-# Clarify-Spec v2.0: Automatische Auftragsklarung
+# Clarify-Spec v3.0: Auftragsklaerung mit hoher Schwelle
 
-## AKTIVIERUNG: Aggressiv - Lieber einmal zu oft!
+## Grundhaltung
 
-### AUTOMATISCH bei diesen Signalen (EINES genuegt!)
+Dieser Skill ist **kein Reflex**. Sein Vorgaenger (v2.0 "aggressiv, lieber einmal
+zu oft") hat eine Frage-Schleife erzeugt, in der Lara nur noch getippt hat statt
+Arbeit voranzubringen. Das ist der Fehler, den v3.0 verhindert.
 
-| Signal | Beispiele | Warum problematisch |
-|--------|-----------|---------------------|
-| Kurzer Auftrag (<25 Woerter) | Mach den Export besser | Zu wenig Kontext |
-| Keine Dateinamen/Pfade | Optimiere die Performance | Scope unklar |
-| Vage Verben | besser, optimieren, fixen, machen, aendern, verbessern | Nicht operationalisierbar |
-| Unsichere Sprache | irgendwie, vielleicht, mal eben, schnell | Signalisiert Unklarheit |
-| Fehlende Erfolgskriterien | Kein damit, sodass, weil | Kein Ziel definiert |
-| Relative Begriffe | schneller, besser, schoener, einfacher | Ohne Baseline bedeutungslos |
-| Implizite Annahmen | Das uebliche, wie immer, standard | Kontext fehlt |
+Die Regel ist: **Erst selbst nachsehen. Dann eine Senior-Entscheidung treffen.
+Nur wenn eine echte Ziel-Mehrdeutigkeit bleibt — einmal gebuendelt fragen.**
 
-### NICHT aktivieren NUR wenn ALLE erfuellt:
-- Konkreter Dateiname/Pfad genannt UND
-- Klares, messbares Ziel definiert UND
-- Erfolgskriterium erkennbar UND
-- Expliziter Skip-Befehl (mach einfach, keine Rueckfragen)
+Ein kurzer Auftrag ist kein Problem. Ein vages Verb ist kein Problem. Ein fehlender
+Dateiname ist kein Problem — den findet man mit Grep. Ein *echt mehrdeutiges Ziel*
+ist ein Problem.
+
+## Wann dieser Skill triggert (hohe Schwelle)
+
+NUR wenn nach eigener Recherche mindestens eines davon zutrifft:
+
+| Echte Mehrdeutigkeit | Beispiel |
+|---|---|
+| Das Ziel selbst ist unklar/widerspruechlich | "mach es wie besprochen" — es gibt keine Notiz, was besprochen wurde |
+| Mehrere grundlegend verschiedene Interpretationen | "raeum die Auth auf" — koennte Refactor, Logging, Token-Rotation oder Tests heissen, alle plausibel |
+| Information fehlt, die NIRGENDS im Repo steht | "nutz die neue API" — keine API im Code, kein Doc, kein Issue |
+| Irreversible Aktion mit unklarem Scope | "loesch die alten Branches" — welche genau? unwiederbringlich |
+
+## Wann dieser Skill NICHT triggert
+
+Bei all dem: NICHT fragen — recherchieren und arbeiten.
+
+- Kurzer Auftrag ("fix den Export-Bug") → Bug suchen, fixen.
+- Vages Verb ("mach die Seite besser") → wenn der Kontext den Mangel klarmacht
+  (offensichtlicher Bug, kaputtes Layout): beheben. Wenn wirklich offen: EINE
+  gebuendelte Frage, was "besser" konkret heisst — aber erst nach Ansehen der Seite.
+- Kein Dateiname genannt → Glob/Grep findet die Datei.
+- "wie immer" / "das uebliche" → Git-History und bestehende Patterns zeigen das Uebliche.
 
 ## Workflow
 
-### Phase 1: Vagheits-Check (STRENG)
+### Phase 1: Eigenrecherche zuerst (immer, still, ohne User)
 
-Pruefe jeden Auftrag gegen diese Checkliste:
+Bevor irgendeine Frage gestellt wird:
 
-[ ] Konkrete Datei/Komponente genannt?
-[ ] Klares, messbares Ziel definiert?
-[ ] Erfolgskriterium erkennbar?
-[ ] Scope abgegrenzt?
-[ ] Keine vagen Verben verwendet?
+1. Relevante Dateien suchen (Glob/Grep) und lesen.
+2. CLAUDE.md / AGENTS.md / Memory pruefen.
+3. Git-History und aehnliche bestehende Implementierungen ansehen.
+4. No-Touch-Zones identifizieren.
 
-Weniger als 4 Haken = RUECKFRAGEN STELLEN!
+Nach Phase 1 ist die Frage in den allermeisten Faellen beantwortet. Dann: **direkt
+arbeiten, Phase 2-4 ueberspringen.**
 
-### Phase 2: Kontext sammeln (still, ohne User-Interaktion)
+### Phase 2: Echtheits-Pruefung der Unklarheit
 
-1. Relevante Dateien im Projekt suchen (Glob)
-2. CLAUDE.md / AGENTS.md pruefen
-3. No-Touch Zones identifizieren
-4. Aehnliche bestehende Implementierungen finden
+Bleibt nach Phase 1 etwas offen — pruefen: Ist das eine **echte
+Ziel-Mehrdeutigkeit** (Tabelle oben) oder nur ein Detail, das eine
+Senior-Entscheidung verträgt?
 
-### Phase 3: Gezielte Rueckfragen (2-4, priorisiert)
+- Detail, das man vernuenftig selbst entscheiden kann → entscheiden, Annahme im
+  Ergebnis dokumentieren, weiterarbeiten.
+- Echte Ziel-Mehrdeutigkeit → Phase 3.
 
-Format - kurz und praezise:
+### Phase 3: EIN gebuendelter Fragen-Block
 
-Bevor ich loslege - kurze Klaerung:
+Wenn gefragt werden muss: **alle offenen Punkte auf einmal** ueber das
+`AskUserQuestion`-Tool (bis zu 4 Fragen gleichzeitig). Nicht nacheinander, nicht
+ueber mehrere Nachrichten verteilt.
 
-1. [KONKRETSTE FRAGE - WAS genau?]
-2. [ZWEITWICHTIGSTE FRAGE - WO/Welche Datei?]
-3. [Optional: Erfolgskriterium?]
-4. [Optional: Gibt es ein Beispiel/Referenz?]
+Fragen-Prioritaet — nur was wirklich offen ist:
 
-(Oder sag mach einfach - dann entscheide ich nach bestem Wissen.)
+| Prio | Typ | Wann fragen |
+|------|-----|-------------|
+| 1 | ZIEL | Das Ziel selbst ist mehrdeutig — welche Interpretation? |
+| 2 | SCOPE | Bei irreversiblen Aktionen: was genau ist betroffen? |
+| 3 | INFO | Information fehlt, die nirgends im Repo steht |
 
-Fragen-Prioritaet:
+WAS/WO-Fragen ("welche Datei?", "Frontend oder Backend?") gehoeren NICHT hierher —
+die beantwortet Phase 1.
 
-| Prio | Typ | Beispiel-Fragen |
-|------|-----|-----------------|
-| 1 | WAS | Was genau meinst du mit besser? Welches Problem soll geloest werden? |
-| 2 | WO | Welche Datei/Komponente ist betroffen? Frontend oder Backend? |
-| 3 | ERFOLG | Woran erkenne ich, dass es fertig ist? Was ist das erwartete Ergebnis? |
-| 4 | BEISPIEL | Gibt es eine Referenz/Screenshot? Wie sieht der gewuenschte Output aus? |
-| 5 | KONTEXT | Fuer welchen Use Case? Wer ist der Nutzer dieser Funktion? |
+### Phase 4: Nach den Antworten — autonom
 
-### Phase 4: Strukturierter Output (JSON fuer prompt-architect)
-
-Nach Antwort des Users, generiere strukturiertes JSON mit:
-- clarified_task.goal: Praezises Ziel in 1-2 Saetzen
-- clarified_task.problem_statement: Was ist das Problem
-- clarified_task.scope.files: Betroffene Dateien
-- clarified_task.scope.no_touch: Nicht anfassen
-- clarified_task.success_criteria: Messbare Kriterien
-- clarified_task.constraints: Einschraenkungen
-- metadata.original_request: Urspruenglicher Auftrag
-- metadata.confidence: high/medium/low
-
-### Phase 5: Bestaetigung mit Prompt-Vorschau
-
-Zeige dem User eine lesbare Zusammenfassung mit Ziel, Problem, Scope, Erfolgskriterien, Constraints.
-
-Frage: Soll ich loslegen? (ja / nein / anpassen: ...)
-Oder: /prompt-architect fuer einen strukturierten Best-Practice Prompt
-
-### Phase 6: Reaktion auf Bestaetigung
-
-| Antwort | Aktion |
-|---------|--------|
-| ja / ok / los / mach | Ausfuehren mit internem JSON-Kontext |
-| nein / stop / abbrechen | Abbrechen, nachfragen was stattdessen |
-| anpassen: ... | JSON modifizieren, erneut zeigen |
-| /prompt-architect | An prompt-architect Skill uebergeben |
-| mach einfach | Mit eigenem Ermessen ausfuehren |
+Sobald die Antworten da sind: **durcharbeiten bis fertig.** Keine weitere
+Rueckfrage, kein Approval-Checkpoint pro Schritt, kein erneutes Klaeren. Nur ein
+echter, vorher unsichtbarer Blocker rechtfertigt eine weitere Frage.
 
 ## Escape Hatches
 
-User kann Klaerung jederzeit ueberspringen mit:
-- Mach einfach
-- Entscheide selbst
-- Keine Rueckfragen
-- Egal, hauptsache X funktioniert
-- Just do it
+Klaerung wird komplett uebersprungen bei:
+- "Mach einfach" / "Entscheide selbst" / "Keine Rueckfragen"
+- "Egal, hauptsache X funktioniert" / "Just do it"
 
-Bei Escape: Mit bestem Wissen ausfuehren, aber Annahmen dokumentieren.
+Bei Escape: mit bestem Wissen ausfuehren, getroffene Annahmen am Ende kurz nennen.
 
-## Integration mit prompt-architect
+## Verhaeltnis zu prompt-architect
 
-Nach erfolgreicher Klaerung kann der User /prompt-architect aufrufen.
-Der prompt-architect Skill nutzt das JSON aus Phase 4, um einen vollstaendigen
-Best-Practice Prompt nach Claude 4.x Standards zu generieren.
+`prompt-architect` triggert NICHT mehr automatisch nach diesem Skill. Wenn ein
+strukturierter Prompt gebraucht wird, ruft der User `/prompt-architect` explizit auf.
 
-Workflow:
-clarify-spec -> JSON Output -> prompt-architect -> Ausfuehrung
-
-## Metrik: Erfolg
+## Erfolgs-Metrik
 
 Der Skill ist erfolgreich wenn:
-- Weniger Nacharbeit nach Implementierung
-- User sagt Ja, genau das meinte ich
-- Erste Implementierung erfuellt alle Kriterien
-- Keine Das meinte ich nicht Situationen
+- Lara NICHT in einer Frage-Schleife sitzt.
+- Normale Alltagsauftraege ohne Rueckfrage erledigt werden.
+- Gefragt wird nur bei echter Mehrdeutigkeit — und dann genau einmal.
+- Keine "das meinte ich nicht"-Situationen, weil Phase 1 den Kontext liefert.

--- a/skills/prompt-architect/README.md
+++ b/skills/prompt-architect/README.md
@@ -26,12 +26,13 @@ cp SKILL.md README.md ~/.claude/skills/prompt-architect/
 
 ## Verwendung
 
-### Nach clarify-spec (empfohlen)
+### Mit vorheriger Klärung
 
 1. User gibt vagen Auftrag
-2. clarify-spec stellt Rueckfragen, generiert JSON
-3. /prompt-architect transformiert JSON in Best-Practice Prompt
-4. Ausfuehrung mit Quality Gates
+2. clarify-spec klaert nur bei echter Ziel-Mehrdeutigkeit und nur einmal gebuendelt
+3. User ruft /prompt-architect explizit auf
+4. prompt-architect transformiert den geklaerten Kontext in einen Best-Practice Prompt
+5. Ausfuehrung mit Quality Gates
 
 ### Standalone
 
@@ -56,10 +57,10 @@ cp SKILL.md README.md ~/.claude/skills/prompt-architect/
 
 ## Workflow
 
-clarify-spec (Anforderungen sammeln)
+clarify-spec (optional, nur bei echter Mehrdeutigkeit)
        |
        v
-  JSON Output
+expliziter /prompt-architect Aufruf
        |
        v
 prompt-architect (Best-Practice Prompt)

--- a/skills/prompt-architect/SKILL.md
+++ b/skills/prompt-architect/SKILL.md
@@ -8,8 +8,8 @@ description: |
   - Anthropic Claude 4.x Best Practices: Explizitheit, Contract-Style, Examples beat Adjectives
   - Pipelines over Prompts Philosophie
   
-  AKTIVIERT SICH AUTOMATISCH nach clarify-spec oder bei /prompt-architect.
-  Produziert strukturierten, ausfuehrbaren Prompt mit allen Best Practices.
+  Wird AUSSCHLIESSLICH per /prompt-architect aufgerufen — KEINE automatische
+  Aktivierung. Produziert strukturierten, ausfuehrbaren Prompt mit allen Best Practices.
 triggers:
   - /prompt-architect
   - /prompt
@@ -28,12 +28,16 @@ triggers:
 
 ## AKTIVIERUNG
 
-### Automatisch nach clarify-spec
-Wenn clarify-spec ein JSON Output generiert hat, kann prompt-architect
-dieses JSON in einen strukturierten Prompt transformieren.
+**Nur manuell.** Dieser Skill aktiviert sich NICHT automatisch — auch nicht nach
+clarify-spec. Die fruehere Auto-Kette (clarify-spec -> prompt-architect) wurde
+entfernt, weil sie eine Klaerungs-Schleife verstaerkt hat.
 
 ### Manuell mit Trigger
 /prompt-architect [Aufgabenbeschreibung]
+
+Falls ein clarify-spec-Lauf vorausging und ein JSON-Ergebnis vorliegt, kann
+prompt-architect dieses JSON nutzen — aber nur, wenn der User /prompt-architect
+explizit aufruft.
 
 ## Die 4 Beginner Moves (Nate B. Jones)
 

--- a/skills/prompt-architect/SKILL.md
+++ b/skills/prompt-architect/SKILL.md
@@ -145,7 +145,8 @@ Before responding, verify:
 ### Schritt 1: Input analysieren
 
 Akzeptiert:
-1. JSON von clarify-spec (bevorzugt)
+1. JSON oder Kontext aus einem vorherigen clarify-spec-Lauf, wenn der User danach
+   explizit /prompt-architect aufruft
 2. Freie Textbeschreibung
 3. Kombiniert mit aktuellem Projekt-Kontext
 
@@ -259,8 +260,8 @@ Der generierte Prompt ist optimiert fuer:
 
 ## Integration
 
-### Mit clarify-spec
-clarify-spec -> JSON -> prompt-architect -> Ausfuehrung
+### Nach clarify-spec
+clarify-spec -> User ruft /prompt-architect explizit auf -> Prompt -> Ausfuehrung
 
 ### Mit /supervisor
 prompt-architect -> Prompt -> /supervisor -> Quality Gates -> Ergebnis


### PR DESCRIPTION
## Problem

`clarify-spec` v2.0 hat sich bei praktisch jedem kurzen Alltagsauftrag aktiviert. Die Skill-Description sagte "AKTIVIERT SICH AUTOMATISCH", kurze Auftraege, vage Verben und fehlende Dateinamen reichten als Trigger. Das erzeugte eine Frage-Schleife statt autonomer Arbeit.

`prompt-architect` verstaerkte das ueber die alte Auto-Kette nach `clarify-spec`.

## Aenderung

**`clarify-spec` v3.0:**
- Triggert nur noch bei echter Ziel-Mehrdeutigkeit nach Eigenrecherche.
- Kurze Auftraege, vage Verben und fehlende Dateinamen sind keine Trigger mehr.
- Wenn gefragt werden muss: alle Fragen einmal gebuendelt, danach autonom durcharbeiten.
- `commands/clarify-spec.md` ist auf denselben High-Threshold-Workflow umgestellt.

**`prompt-architect`:**
- Keine automatische Aktivierung nach `clarify-spec`.
- Nutzung nach `clarify-spec` nur noch, wenn der User `/prompt-architect` explizit aufruft.

**Dokumentation:**
- README-Kopien fuer `clarify-spec` und `prompt-architect` aktualisiert.
- Top-Level- und `skills/`-Kopien bleiben inhaltlich identisch.

## Verifikation

- `git diff --check origin/main...HEAD` clean.
- Top-Level- und `skills/`-Kopien per `Compare-Object` geprueft.
- Stale Begriffe/Altpfade gesucht: keine Treffer fuer alte Auto-Trigger, Vercel, `/api/analyze`, alte `prompt-architect`-Auto-Kette.
- CodeRabbit Status: gruen / skipped.

## Merge-Hinweis

Dieser PR muss vor `Svenja-dev/claude-config#8` gemerged werden, damit der dortige Submodul-Pointer auf einen Commit auf `claude-code-skills/main` zeigt.